### PR TITLE
Fixed issue #8

### DIFF
--- a/include/arr.h
+++ b/include/arr.h
@@ -1081,7 +1081,7 @@ public:
      * Construct an empty StrArray.
      */
     StrArray() :
-        ObjArray(StrArray::compare)
+        ObjArray<std::string>(StrArray::compare)
     {
     }
 


### PR DESCRIPTION
Issue YasserAsmi/jvar#8 is fixed by adding an explicit template instantiation to the constructor prototype StrArray::StrArray(). This issue only affects G++ versions < 4.5, but the fix is valid C++ and shouldn't break anything for anyone else. See the comments in the issue for more info.