### PR TITLE
Added build option to enable adding properties on assignment (without addProperty).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Wno-unused-parameter 
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wall -Wextra -Wno-unused-parameter -Wno-variadic-macros -Wno-ignored-qualifiers")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
+option(AUTOADDPROP "Enable adding properties on assignment, without using addProperty" OFF)
+message(STATUS "AUTOADDPROP = " ${AUTOADDPROP})
+if(AUTOADDPROP)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DAUTOADDPROP")
+endif(AUTOADDPROP)
+
 add_library(jvar STATIC src/str.cpp src/util.cpp src/arr.cpp src/var.cpp src/json.cpp)
 
 add_executable(ex_basics example/basics.cpp)

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -530,6 +530,11 @@ void Variant::createObject(const char* initvalue /* = NULL*/)
         {
             JsonParser json(*this, initvalue, JsonParser::FLAG_FLEXQUOTES | JsonParser::FLAG_OBJECTONLY);
         }
+
+#ifdef AUTOADDPROP
+        mData.flags |= Variant::VF_AUTOADDPROP;
+#endif
+
     }
     else
     {


### PR DESCRIPTION
Usage: `cmake -DAUTOADDPROP=ON ..`. Closes #14 