### PR TITLE
syntax for handy initializing of the objects using c++11 initializer_list

### DIFF
--- a/example/objs.cpp
+++ b/example/objs.cpp
@@ -86,6 +86,20 @@ void showObjOfArr()
     showIter(obj);
 }
 
+#if __cplusplus > 199711L
+void showAltInit2()
+{
+    Variant obj = {
+        { "PropA", 110 },
+        { "PropB", "my value" },
+        { "PropC", { { "PropOfNestedObj", "my value" } } },
+        { "PropD", { 100, 200, 300, 400, 500 } },
+    };
+
+    showIter(obj);
+}
+
+#endif
 
 int main(int argc, char** argv)
 {
@@ -95,4 +109,8 @@ int main(int argc, char** argv)
     showSimple();
     showAltInit();
     showObjOfArr();
+
+#if __cplusplus > 199711L
+    showAltInit2();
+#endif
 }

--- a/include/var.h
+++ b/include/var.h
@@ -144,6 +144,19 @@ public:
         *this = src;
     }
 
+#if __cplusplus > 199711L
+
+    /**
+     * Assigns an object literal represented by initializer_list
+     */
+    Variant(std::initializer_list<const Variant>&& src)
+    {
+        assignObj(src);
+    }
+
+#endif
+
+
     /**
      * Destructor deletes all data in the object
      */
@@ -949,6 +962,15 @@ private:
      */
     void assignStr(const std::string& src);
 
+#if __cplusplus > 199711L
+
+    /**
+     * Assign an object defined by initializer list to this Variant.
+     */
+    void assignObj(std::initializer_list<const Variant>& src);
+
+#endif
+
     /**
      * Coerce the data in this Variant to a \ref longint.
      */
@@ -1170,5 +1192,7 @@ inline bool operator!=(const Variant& lhs, const char *rhs) { return !(lhs == rh
 
 
 } // jvar
+
+
 
 #endif // _VAR_H

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -1266,6 +1266,44 @@ void Variant::assignBool(bool src)
     }
 }
 
+#if __cplusplus > 199711L
+
+void Variant::assignObj(std::initializer_list<const Variant>& src)
+{
+    bool is_object = true;
+
+    if (src.size() == 0)
+    {
+        createObject();
+        return;
+    }
+
+    for(const auto& v : src)
+    {
+        if (!v.isArray() || v.length() != 2 || !v[0].isString())
+            is_object = false;
+    }
+
+    if (is_object)
+    {
+        createObject();
+        for(const auto& v : src)
+        {
+            addProperty(v[0].toString(), v[1]);
+        }
+    }
+    else
+    {
+        createArray();
+        for (const auto& v: src)
+        {
+            push(v);
+        }
+    }
+}
+
+#endif
+
 std::string& Variant::s()
 {
     if (mData.type != V_STRING)


### PR DESCRIPTION
Hi!

I was able to eliminate call to a function for creating objects, and also produce a way to initialize arrays as well.

This is the final syntax:
```c++
    Variant obj = {
        { "PropA", 110 },
        { "PropB", "my value" },
        { "PropC", { { "PropOfNestedObj", "my value" } } },
        { "PropD", { 100, 200, 300, 400, 500 } },
    };
```

which is the same as the following js:
```js
    var obj = {
        PropA: 110,
        PropB: "my value",
        PropC: { PropOfNestedObj: "my value"  },
        PropD: [ 100, 200, 300, 400, 500 ],
    };

```

It seems this is pretty much as far as one can get with c++11.

Please don't hesitate to do any fixes or corrections as you feel necessary!

Closes #17